### PR TITLE
v0.0.4: Fixes and small performance improvements

### DIFF
--- a/docker/base-py2.Dockerfile
+++ b/docker/base-py2.Dockerfile
@@ -28,7 +28,7 @@ RUN \
 
 # FIXME python 2 support in pip is starting to break down
 # https://github.com/jaraco/zipp/issues/16
-RUN pip install zipp
+RUN pip install zipp==1.0.0
 
 COPY . /opt/oarphpy
 WORKDIR /opt/oarphpy

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tensorflow/tensorflow:1.15.0-jupyter
+FROM tensorflow/tensorflow:1.15.2-jupyter
 
 # We don't care for __pycache__ and .pyc files; sometimes VSCode doesn't clean
 # up properly when deleting things and the cache gets stale.
@@ -34,7 +34,7 @@ RUN \
     curl \
     git \
     python-dev \
-    python-pip \
+    python3-pip \
     python3-dev \
     wget
 

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -28,15 +28,15 @@ RUN pip uninstall -y enum34
 
 ### Core
 ### Required for installing and testing things
-RUN apt-get update
 RUN \
+  apt-get update && \
   apt-get install -y \
-  curl \
-  git \
-  python-dev \
-  python-pip \
-  python3-dev \
-  wget
+    curl \
+    git \
+    python-dev \
+    python-pip \
+    python3-dev \
+    wget
 
 
 ### Spark (& Hadoop)
@@ -68,6 +68,7 @@ RUN curl -L --retry 3 \
 
 ## Java 8.  NB: can't use Java 11 yet for Spark
 RUN \
+  apt-get update && \
   apt-get install -y openjdk-8-jdk && \
   ls -lhat /usr/lib/jvm/java-8-openjdk-amd64 && \
   echo JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 >> /etc/environment

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tensorflow/tensorflow:1.15.0-py3-jupyter
+FROM tensorflow/tensorflow:1.15.0-jupyter
 
 # We don't care for __pycache__ and .pyc files; sometimes VSCode doesn't clean
 # up properly when deleting things and the cache gets stale.

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -55,7 +55,7 @@ RUN curl -L --retry 3 \
  && mv /opt/hadoop-$HADOOP_VERSION $HADOOP_HOME \
  && rm -rf $HADOOP_HOME/share/doc
 
-ENV SPARK_VERSION 2.4.4
+ENV SPARK_VERSION 2.4.5
 ENV SPARK_PACKAGE spark-${SPARK_VERSION}-bin-without-hadoop
 ENV SPARK_HOME /opt/spark
 ENV SPARK_DIST_CLASSPATH "$HADOOP_HOME/etc/hadoop/*:$HADOOP_HOME/share/hadoop/common/lib/*:$HADOOP_HOME/share/hadoop/common/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/hdfs/lib/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/yarn/lib/*:$HADOOP_HOME/share/hadoop/yarn/*:$HADOOP_HOME/share/hadoop/mapreduce/lib/*:$HADOOP_HOME/share/hadoop/mapreduce/*:$HADOOP_HOME/share/hadoop/tools/lib/*"

--- a/docker/full.Dockerfile
+++ b/docker/full.Dockerfile
@@ -55,7 +55,7 @@ RUN curl -L --retry 3 \
  && mv /opt/hadoop-$HADOOP_VERSION $HADOOP_HOME \
  && rm -rf $HADOOP_HOME/share/doc
 
-ENV SPARK_VERSION 2.4.5
+ENV SPARK_VERSION 2.4.6
 ENV SPARK_PACKAGE spark-${SPARK_VERSION}-bin-without-hadoop
 ENV SPARK_HOME /opt/spark
 ENV SPARK_DIST_CLASSPATH "$HADOOP_HOME/etc/hadoop/*:$HADOOP_HOME/share/hadoop/common/lib/*:$HADOOP_HOME/share/hadoop/common/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/hdfs/lib/*:$HADOOP_HOME/share/hadoop/hdfs/*:$HADOOP_HOME/share/hadoop/yarn/lib/*:$HADOOP_HOME/share/hadoop/yarn/*:$HADOOP_HOME/share/hadoop/mapreduce/lib/*:$HADOOP_HOME/share/hadoop/mapreduce/*:$HADOOP_HOME/share/hadoop/tools/lib/*"

--- a/docker/spark.Dockerfile
+++ b/docker/spark.Dockerfile
@@ -30,7 +30,7 @@ RUN \
 RUN \
   apt-get install -y openjdk-8-jdk && \
   echo JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 >> /etc/environment
-RUN pip3 install pyspark==2.4.4
+RUN pip3 install pyspark==2.4.6
 RUN pip3 install numpy pandas>=1.0.0
 ENV PYSPARK_PYTHON python3
 ENV PYSPARK_DRIVER_PYTHON python3

--- a/docker/spark.Dockerfile
+++ b/docker/spark.Dockerfile
@@ -31,7 +31,7 @@ RUN \
   apt-get install -y openjdk-8-jdk && \
   echo JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 >> /etc/environment
 RUN pip3 install pyspark==2.4.4
-RUN pip3 install numpy pandas
+RUN pip3 install numpy pandas>=1.0.0
 ENV PYSPARK_PYTHON python3
 ENV PYSPARK_DRIVER_PYTHON python3
 

--- a/docker/tensorflow.Dockerfile
+++ b/docker/tensorflow.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM tensorflow/tensorflow:1.15.0-py3-jupyter
+FROM tensorflow/tensorflow:1.15.2-jupyter
 
 # We don't care for __pycache__ and .pyc files; sometimes VSCode doesn't clean
 # up properly when deleting things and the cache gets stale.

--- a/oarphcli
+++ b/oarphcli
@@ -22,7 +22,7 @@ development workflow.
 
 ## Use & Development
 
-$ ./oarphpy --shell
+$ ./oarphcli --shell
 Drop into a dockerized dev environment shell, do some work. Local code mounted
 at /opt/oarphpy, and outer filesystem mounted at /outer_root .
 
@@ -33,10 +33,10 @@ $$ pytest
 $$ python setup.up test
 In the dockerized shell, run unit tests using your local code changes.
 
-$ ./oarphpy --test-all
+$ ./oarphcli --test-all
 Outside the container, run unit tests in all environments.
 
-$ ./oarphpy --build-env --push-as-latest
+$ ./oarphcli --build-env --push-as-latest
 Rebuild all dockerized environments
 
 
@@ -44,7 +44,7 @@ Rebuild all dockerized environments
 
 To update the oarphpy package version, first edit `oarphpy/__init__.py`.
 Push your changes to the master branch, then on master run:
-$ ./oarphpy --release
+$ ./oarphcli --release
 
 """
 

--- a/oarphpy/__init__.py
+++ b/oarphpy/__init__.py
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.0.3'
+__version__ = '0.0.4'
 

--- a/oarphpy/spark.py
+++ b/oarphpy/spark.py
@@ -799,6 +799,8 @@ class NBSpark(SessionFactory):
 ### Spark SQL Type Adaption Utils
 ###
 
+TENSOR_AUTO_PACK_MIN_BYTES = 500 * (2**10) # 500KBytes
+
 class Tensor(object):
   """An ndarray-like object designed to store numpy arrays in Parquet / 
   Spark SQL format.  Spark's DenseVector and Matrix unfortunately don't 
@@ -806,7 +808,7 @@ class Tensor(object):
   an explicit order accessible to external readers such as Eigen in C++
   or nd4j / BLAS wrappers in Java.
   """
-  __slots__ = ('shape', 'dtype', 'order', 'values')
+  __slots__ = ('shape', 'dtype', 'order', 'values', 'values_packed')
 
   @staticmethod
   def from_numpy(arr):
@@ -814,13 +816,24 @@ class Tensor(object):
     t.shape = list(arr.shape)
     t.dtype = arr.dtype.name
     t.order = 'C' # C-style row-major
-    t.values = arr.flatten(order='C').tolist()
+
+    if arr.nbytes >= TENSOR_AUTO_PACK_MIN_BYTES:
+      t.values = []
+      t.values_packed = bytearray(np.tobytes(order='C'))
+    else:
+      t.values = arr.flatten(order='C').tolist()
+      t.values_packed = bytearray()
     return t
   
   @staticmethod
   def to_numpy(t):
     import numpy as np
-    return np.array(
+    if t.values_packed:
+      return np.reshape(
+        np.frombuffer(t.values_packed, dtype=np.dtype(t.dtype)),
+        t.shape)
+    else:
+      return np.array(
               np.reshape(t.values, t.shape, order=t.order),
               dtype=np.dtype(t.dtype))
 

--- a/oarphpy/spark.py
+++ b/oarphpy/spark.py
@@ -799,7 +799,7 @@ class NBSpark(SessionFactory):
 ### Spark SQL Type Adaption Utils
 ###
 
-TENSOR_AUTO_PACK_MIN_BYTES = 500 * (2**10) # 500KBytes
+TENSOR_AUTO_PACK_MIN_KBYTES = 2
 
 class Tensor(object):
   """An ndarray-like object designed to store numpy arrays in Parquet / 
@@ -817,9 +817,9 @@ class Tensor(object):
     t.dtype = arr.dtype.name
     t.order = 'C' # C-style row-major
 
-    if arr.nbytes >= TENSOR_AUTO_PACK_MIN_BYTES:
+    if arr.nbytes >= TENSOR_AUTO_PACK_MIN_KBYTES * (2**10):
       t.values = []
-      t.values_packed = bytearray(np.tobytes(order='C'))
+      t.values_packed = bytearray(arr.tobytes(order='C'))
     else:
       t.values = arr.flatten(order='C').tolist()
       t.values_packed = bytearray()

--- a/oarphpy/spark.py
+++ b/oarphpy/spark.py
@@ -67,7 +67,7 @@ except Exception as e:
       That will fix import errors.  To get Java, try:
         $ apt-get install -y openjdk-8-jdk && echo JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64 >> /etc/environment
       If you have spark installed locally (e.g. from source), set $SPARK_HOME
-      Original error: %s
+      *** Original error: %s
   """ % (e,)
   raise ImportError(msg)
 

--- a/oarphpy/spark.py
+++ b/oarphpy/spark.py
@@ -394,7 +394,7 @@ class SessionFactory(object):
   
   # Default set of `SparkConf` key-value settings to use for any new sesion,
   # e.g. {
-  #   'spark.port.maxRetries', '96'
+  #   'spark.port.maxRetries': '96',
   #       # For local instances with many CPUs, let Spark use tons of ports
   #
   #   'spark.driver.memory': '8g',

--- a/oarphpy/spark.py
+++ b/oarphpy/spark.py
@@ -433,7 +433,6 @@ class SessionFactory(object):
   def _resolve_src_root(cls):
     src_root = cls.SRC_ROOT
     if src_root is None:
-      util.log.info("Trying to auto-resolve path to src root ...")
       try:
         import inspect
         frames = inspect.stack()#[2][0]
@@ -458,7 +457,6 @@ class SessionFactory(object):
         if not src_root:
           raise ValueError("Ran out of candidate stack frames")
       except Exception as e:
-        assert False, e
         util.log.info(
           "Failed to auto-resolve src root (error: %s) "
           "falling back to %s" % (e, cls.SRC_ROOT))

--- a/oarphpy/util/misc.py
+++ b/oarphpy/util/misc.py
@@ -33,26 +33,46 @@ def np_truthy(v):
     return bool(v)
 
 
+try:
+  import six
+  FIXED_SIZE_TYPES = tuple(itertools.chain.from_iterable(
+        (six.integer_types, (float,))))
+  INTEGRAL_TYPES = tuple(itertools.chain.from_iterable(
+        (six.string_types, six.class_types, FIXED_SIZE_TYPES)))
+except Exception as e:
+  FIXED_SIZE_TYPES = tuple()
+  INTEGRAL_TYPES = tuple()
+
 def get_size_of_deep(v):
   """(Hacky) Get size of the value `v` in bytes.  Does not rely on a more
   precise library like guppy or pympler.  Intended for values `v` that 
   contain large binary blobs."""
-  import six
-  INTEGRAL_TYPES = tuple(itertools.chain.from_iterable(
-        (six.string_types, six.integer_types, six.class_types,
-        (bytes, bytearray))))
-    # The above types can trigger expensive recursion unless we base case them
+
+  # NB: requires `six` module!
+  
   if isinstance(v, INTEGRAL_TYPES):
+    # These types can trigger expensive recursion unless we base case them
     return sys.getsizeof(v)
-  if hasattr(v, 'nbytes'):
+  elif hasattr(v, 'nbytes'):
     return v.nbytes
   elif hasattr(v, 'items'):
     # Typically a dict
     return sum(
       get_size_of_deep(key) + get_size_of_deep(value)
       for key, value in v.items())
-  elif hasattr(v, '__iter__'):
+  elif hasattr(v, '__len__') and hasattr(v, '__getitem__'):
     # Typically a list or tuple
+    if len(v) == 0:
+      return 0
+    if isinstance(v[0], FIXED_SIZE_TYPES):
+      return len(v[0]) * sys.getsizeof(v[0])
+    else:
+      return sum(get_size_of_deep(v[i]) for i in range(len(v)))
+  elif hasattr(v, '__next__'):
+    # Don't consume generators
+    return sys.getsizeof(v)
+  elif hasattr(v, '__iter__'):
+    # Some other sequence type, but NOT a generator (see above)
     return sum(get_size_of_deep(el) for el in iter(v))
   elif hasattr(v, '__dict__'):
     return sum(

--- a/oarphpy/util/misc.py
+++ b/oarphpy/util/misc.py
@@ -68,7 +68,8 @@ def get_size_of_deep(v):
       return len(v) * sys.getsizeof(v[0])
     else:
       return sum(get_size_of_deep(v[i]) for i in range(len(v)))
-  elif hasattr(v, '__next__'):
+  elif hasattr(v, '__next__') or (
+            sys.version_info[0] == 2 and hasattr(v, 'next')):
     # Don't consume generators
     return sys.getsizeof(v)
   elif hasattr(v, '__iter__'):

--- a/oarphpy/util/misc.py
+++ b/oarphpy/util/misc.py
@@ -38,7 +38,8 @@ try:
   FIXED_SIZE_TYPES = tuple(itertools.chain.from_iterable(
         (six.integer_types, (float,))))
   INTEGRAL_TYPES = tuple(itertools.chain.from_iterable(
-        (six.string_types, six.class_types, FIXED_SIZE_TYPES)))
+        (six.string_types, six.class_types,
+          (bytes, bytearray), FIXED_SIZE_TYPES)))
 except Exception as e:
   FIXED_SIZE_TYPES = tuple()
   INTEGRAL_TYPES = tuple()

--- a/oarphpy/util/misc.py
+++ b/oarphpy/util/misc.py
@@ -65,7 +65,7 @@ def get_size_of_deep(v):
     if len(v) == 0:
       return 0
     if isinstance(v[0], FIXED_SIZE_TYPES):
-      return len(v[0]) * sys.getsizeof(v[0])
+      return len(v) * sys.getsizeof(v[0])
     else:
       return sum(get_size_of_deep(v[i]) for i in range(len(v)))
   elif hasattr(v, '__next__'):

--- a/oarphpy_test/test_spark.py
+++ b/oarphpy_test/test_spark.py
@@ -356,12 +356,10 @@ class Unslotted(object):
 
 
 def _pandas_compare_str(pdf, expected):
-  import pandas as pd
-  pd.set_option('display.max_colwidth', None)
   def cleaned(s):
     lines = [l.strip() for l in s.split('\n')]
     return '\n'.join(l for l in lines if l)
-  assert cleaned(str(pdf)) == cleaned(expected)
+  assert cleaned(pdf.to_string()) == cleaned(expected)
 
 
 def _check_serialization(spark, rows, testname, schema=None):

--- a/oarphpy_test/test_spark.py
+++ b/oarphpy_test/test_spark.py
@@ -594,3 +594,13 @@ def test_row_adapter_with_slotted_attrs():
     1  oarphpy_test.test_spark.AttrsSlotted  (oarphpy.spark.Tensor, float64, C, [1], [1.0])    5  moof
     """
     _pandas_compare_str(df.orderBy('foo').toPandas(), EXPECTED)
+
+
+@skip_if_no_spark
+def test_row_adapter_packed_numpy_arr():
+  import sys
+  from oarphpy.spark import TENSOR_AUTO_PACK_MIN_BYTES
+
+  expect_unpacked = np.array(range(10))
+  
+

--- a/oarphpy_test/test_spark.py
+++ b/oarphpy_test/test_spark.py
@@ -245,8 +245,8 @@ def test_get_balanced_sample():
     expected_arr = np.array([expected[k] for k in ks])
     
     import numpy.testing as npt
-    npt.assert_allclose(actual_arr, expected_arr, rtol=0.2)
-      # NB: We can only test to about 20% accuracy with this few samples
+    npt.assert_allclose(actual_arr, expected_arr, rtol=0.3)
+      # NB: We can only test to about 30% accuracy with this few samples
 
   with testutil.LocalSpark.sess() as spark:
     df = spark.createDataFrame(rows)

--- a/oarphpy_test/test_util/test_misc.py
+++ b/oarphpy_test/test_util/test_misc.py
@@ -43,6 +43,11 @@ class TestGetSizeOfDeep(unittest.TestCase):
     assert util.get_size_of_deep("") == sys.getsizeof("")
     assert util.get_size_of_deep(0) == sys.getsizeof(0)
 
+    bs = b"abc"
+    assert util.get_size_of_deep(bytes(bs)) == sys.getsizeof(bytes(bs))
+    assert \
+      util.get_size_of_deep(bytearray(bs)) == sys.getsizeof(bytearray(bs))
+
   def test_sequences(self):
     pytest.importorskip('six', reason='Uses six for compatibility')
 

--- a/oarphpy_test/test_util/test_misc.py
+++ b/oarphpy_test/test_util/test_misc.py
@@ -53,6 +53,16 @@ class TestGetSizeOfDeep(unittest.TestCase):
     assert util.get_size_of_deep({0: 0}) == 2 * sys.getsizeof(0)
     assert util.get_size_of_deep({0: [0]}) == 2 * sys.getsizeof(0)
 
+  def test_generators(self):
+    a = [1, 2]
+    assert util.get_size_of_deep(iter(a)) == 5
+
+    def ima_gen():
+      for i in range(10):
+        yield i
+    
+    assert util.get_size_of_deep(ima_gen()) == sys.getsizeof(ima_generator)
+
   def test_obj(self):
     pytest.importorskip('six', reason='Uses six for compatibility')
 
@@ -83,6 +93,14 @@ class TestGetSizeOfDeep(unittest.TestCase):
     assert util.get_size_of_deep([arr]) == arr.nbytes
     assert util.get_size_of_deep([arr, arr]) == 2 * arr.nbytes
     assert util.get_size_of_deep({0: arr}) == (sys.getsizeof(0) + arr.nbytes)
+
+  def test_big_lists(self):
+    pytest.importorskip('six', reason='Uses six for compatibility')
+
+    # Case: consider we have a large array, like a Tensor
+    # but as a list. We want get_size_of_deep() to be fast.
+    arr = list(range(int(1e7)))
+    assert util.get_size_of_deep(arr) == (len(arr) * sys.getsizeof(0))
 
 
 def test_stable_hash():

--- a/oarphpy_test/test_util/test_misc.py
+++ b/oarphpy_test/test_util/test_misc.py
@@ -55,13 +55,13 @@ class TestGetSizeOfDeep(unittest.TestCase):
 
   def test_generators(self):
     a = [1, 2]
-    assert util.get_size_of_deep(iter(a)) == 5
+    assert util.get_size_of_deep(iter(a)) == sys.getsizeof(iter(a))
 
     def ima_gen():
       for i in range(10):
         yield i
     
-    assert util.get_size_of_deep(ima_gen()) == sys.getsizeof(ima_generator)
+    assert util.get_size_of_deep(ima_gen()) == sys.getsizeof(ima_gen())
 
   def test_obj(self):
     pytest.importorskip('six', reason='Uses six for compatibility')
@@ -99,8 +99,12 @@ class TestGetSizeOfDeep(unittest.TestCase):
 
     # Case: consider we have a large array, like a Tensor
     # but as a list. We want get_size_of_deep() to be fast.
-    arr = list(range(int(1e7)))
+    arr = list(range(int(1e6)))
     assert util.get_size_of_deep(arr) == (len(arr) * sys.getsizeof(0))
+
+    # A big list of strings will still require a slower reduce
+    ss = list(str(i) for i in range(100))
+    assert util.get_size_of_deep(ss) == sum(sys.getsizeof(s) for s in ss)
 
 
 def test_stable_hash():

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ if not HAVE_SYSTEM_SPARK:
 
 TF_DEPS = [
   'crcmod',
-  'tensorflow<=1.15.0',
+  'tensorflow<=1.15.2',
 ]
 
 UTILS = [

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,18 @@ def find_version():
 setup_requires = ['pytest-runner']
 tests_require = ['pytest']
 if sys.version_info[0] < 3:
-  setup_requires = ['pytest-runner<5']
-  tests_require = ['pytest<5']
+  setup_requires = [
+    'pytest-runner==4.2.0',
+    # Pin to a variety of old versions because python2 support is
+    # deteriorating-- new versions break the build
+    'configparser==3.5.0',
+    'contextlib2==0.5.4',
+    'scandir==1.5.0',
+    'importlib-metadata==0.12',
+    'atomicwrites==1.0.0',
+    'attrs==17.4.0',
+  ]
+  tests_require = ['pytest==4.2.0']
 
 ## Optional Dependencies
 # OarphPy works in standard python 2 and 3 environments, but we provide extras


### PR DESCRIPTION
In this update:
 * `spark.Tensor` now automatically stores *packed* tensor data (i.e. as a byte array) if the underlying data exceeds 2 KBytes.  We anticipate that tensors with this much data (or more) don't need to support introspection on a per-element basis (in contrast to, say, rotation matrices or labels).  This change made encoding KITTI point clouds 6x faster 😬 
 * `get_size_of_deep()` was very slow for large lists of fixed-sized elements (e.g. integers); in particular perf was very slow for code that looked like `get_size_of_deep(numpy.array([range(1e6)]).tolist())`.  We now special-case input arrays of integral types to make size computation constant time.
 * `spark.RowAdapter` now thoroughly supports `attrs`-based classes
 *  `get_size_of_deep()` modified to not consume generators when possible 
 * Bump spark version (they took down 2.4.4 from the mirror already :( )
 * Bump Tensorflow to 1.15.2 and adopt their new Docker image naming convention (they're dropping py2 support starting April 2020).